### PR TITLE
fix: make deep copy of default settings arrays

### DIFF
--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -2,7 +2,7 @@ import { ColorsData } from "../types/plugin";
 
 export const MAX_CELL_COUNT: number = 20;
 export const DEFAULT_COLOR: string = '#000000';
-export const DEFAULT_SETTINGS: Partial<ColorsData> = {
+export const DEFAULT_SETTINGS: Readonly<ColorsData> = {
   favoriteColors: [
     "#c00000",
     "#ff0000",

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,7 +100,12 @@ export default class ColoredFont extends Plugin {
     }
 
     async loadColorData() {
-      this.colorsData = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+      this.colorsData = Object.assign({}, 
+        {
+          ...DEFAULT_SETTINGS,
+          colorArr: [...DEFAULT_SETTINGS.colorArr],
+          favoriteColors: [...DEFAULT_SETTINGS.favoriteColors],
+        }, await this.loadData());
       this.curColor = this.colorsData.colorArr[0];
     }
 


### PR DESCRIPTION
issue with reset defaults button when data.json does not exist due to no deep copy of default settings